### PR TITLE
Use latest rrule version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
  , "repository": {"type" : "git", "url" : "git://github.com/peterbraden/ical.js.git"}
  , "dependencies": {
  	"request": ""
-  ,	"rrule": "1.0.1"
+  ,	"rrule": "latest"
  }
  , "devDependencies": {
  	  "vows" : "0.7.0"


### PR DESCRIPTION
I'm just using 'latest' which can be dangerous.  You may want to just use 2.0.0.
