### PR TITLE
take opts into request

### DIFF
--- a/node-ical.js
+++ b/node-ical.js
@@ -5,8 +5,7 @@ var ical = require('./ical')
 exports.fromURL = function(url, opts, cb){
   if (!cb)
     return;
-
-  request({uri:url}, function(err, r, data){
+  request(url, opts, function(err, r, data){
     if (err)
       return cb(err, null);
     cb(undefined, ical.parseICS(data));


### PR DESCRIPTION
At the moment you can pass something like 

```
{
  auth : {
    user : 'foo',
    pass : 'bar'
  }
}
```

but that won't work, because opts are not taken to the request.
(This works for me to get a calendar from radicale via http basic auth)
