### PR TITLE
Fixed #45: RRule doesn't honor start date

### DIFF
--- a/node-ical.js
+++ b/node-ical.js
@@ -21,5 +21,12 @@ var rrule = require('rrule').RRule
 
 ical.objectHandlers['RRULE'] = function(val, params, curr, stack, line){
   curr['rrule'] = rrule.fromString(line.replace("RRULE:", ""));
+
+  // If rrule does not contain a start date
+  // read the start date from the current event
+  if (line.indexOf('DTSTART') != -1) {
+    curr['rrule'].options.dtstart = curr.start;    
+  }
+
   return curr
 }


### PR DESCRIPTION
I also discovered the bug that the start date is not honored. So I fixed it by using the start date from the event if the rrule itself has no start date set.
