### PR TITLE
Import dates without a time component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.idea

--- a/ical.js
+++ b/ical.js
@@ -118,13 +118,16 @@ var UUID = require('node-uuid');
     }
 
     // date format (no time)
-    var comps = /^(\d{4})(\d{2})(\d{2})$/.exec(val);
+    comps = /^(\d{4})(\d{2})(\d{2})$/.exec(val);
     if (comps !== null) {
-      return new Date(Date.UTC(
-        parseInt(comps[1], 10),
+      // No TZ info - assume same timezone as this computer
+      objToReturn = new Date(
+        comps[1],
         parseInt(comps[2], 10)-1,
-        parseInt(comps[3], 10)
-      ));
+        comps[3]
+      );
+
+      return addTZ(objToReturn, params);
     }
   }
 

--- a/ical.js
+++ b/ical.js
@@ -1,3 +1,5 @@
+var UUID = require('node-uuid');
+
 (function(name, definition) {
 
 /****************
@@ -219,11 +221,7 @@
         }
         
         var par = stack.pop()
-
-        if (curr.uid)
-          par[curr.uid] = curr
-        else
-          par[Math.random()*100000] = curr  // Randomly assign ID : TODO - use true GUID
+        par[UUID.v4()] = curr;
 
         return par
       }
@@ -243,6 +241,7 @@
       , 'CATEGORIES': categoriesParam('categories')
       , 'FREEBUSY': freebusyParam('freebusy')
       , 'EXDATE': dateParamArray('exdate')
+      , 'RECURRENCE-ID': storeParam('recurrenceId')
     },
 
 

--- a/ical.js
+++ b/ical.js
@@ -116,6 +116,16 @@ var UUID = require('node-uuid');
         );
       }
     }
+
+    // date format (no time)
+    var comps = /^(\d{4})(\d{2})(\d{2})$/.exec(val);
+    if (comps !== null) {
+      return new Date(Date.UTC(
+        parseInt(comps[1], 10),
+        parseInt(comps[2], 10)-1,
+        parseInt(comps[3], 10)
+      ));
+    }
   }
 
   var dateParam = function(name){

--- a/ical.js
+++ b/ical.js
@@ -56,11 +56,11 @@
   var addTZ = function(dateObj, params){
     var p = parseParams(params);
 
-    if (params && p){
+    if (params && p && dateObj){
       dateObj.tz = p.TZID
     }
 
-    return dateObj
+    return dateObj;
   };
 
   /**
@@ -71,7 +71,7 @@
    * @return {object} The Javascript date object
    */
   function parseDate(val, params, curr) {
-    var objToReturn = {};
+    var objToReturn = val;
 
     if (params && params[0] === "VALUE=DATE") {
       // Just Date
@@ -118,10 +118,14 @@
 
   var dateParam = function(name){
     return function(val, params, curr){
-      // Store as string - worst case scenario
-      storeParam(name)(val, undefined, curr);
       var dateObj = parseDate(val, params, curr);
-      curr[name] = addTZ(dateObj, params);
+      dateObj = addTZ(dateObj, params);
+      if (dateObj) {
+        curr[name] = dateObj;
+      } else {
+        // Store as string - worst case scenario
+        storeParam(name)(val, undefined, curr);
+      }
       return curr;
     }
   };

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "node-uuid": "^1.4.1",
-    "rrule": "2.1.0"
+    "rrule": "2.1.0",
     "request": "2.40.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -15,8 +15,9 @@
     "url": "git://github.com/peterbraden/ical.js.git"
   },
   "dependencies": {
+    "node-uuid": "^1.4.1",
     "request": "",
-    "rrule": "2.0.0"
+    "rrule": "2.1.0"
   },
   "devDependencies": {
     "vows": "0.7.0",

--- a/test/test.js
+++ b/test/test.js
@@ -72,7 +72,7 @@ vows.describe('node-ical').addBatch({
     }
     , 'todo item uid4@host1.com' : {
       topic : function(items){
-        return items['uid4@host1.com']
+        return _.filter(items,function(obj) { { return obj.uid == 'uid4@host1.com'; } })[0];
       }
       , 'is a VTODO' : function(topic){
         assert.equal(topic.type, 'VTODO')


### PR DESCRIPTION
In an ICS event with these properties:
```
DTSTART;TZID=America/New_York:20110625

DTEND;TZID=America/New_York:20110626
```
The dates aren't parsed at JS dates, but returned as strings. This update will return them as date objects.