### PR TITLE
Preventing parsing from failing when not provided FREEBUSY dates

### DIFF
--- a/ical.js
+++ b/ical.js
@@ -19,6 +19,7 @@
 
    // Unescape Text re RFC 4.3.11
   var text = function(t){
+    t = t || "";
     return (t
       .replace(/\\\,/g, ',')
       .replace(/\\\;/g, ';')


### PR DESCRIPTION
eg. if we have the following in an ical
```
FREEBUSY;FBTYPE=FREE:
```
We ultimately end up with no start and end date values and it blows up
trying to replace the strings on undefined