### PR TITLE
Fix 8 digit start dates. (For example with the Facebook birthday calendar)

### DIFF
--- a/node-ical.js
+++ b/node-ical.js
@@ -28,6 +28,17 @@ ical.objectHandlers['END'] = function(val, params, curr, stack){
   if (curr.rrule) {
     var rule = curr.rrule.replace('RRULE:', '');
     if (rule.indexOf('DTSTART') === -1) {
+      
+      // In some cases, the curr.start is just an 8 digit string, like '20160423'. 
+      // In that case we need to convert it to a date object. Otherwise, the next
+      // .toISOString() method will throw an exception.
+      if (curr.start.length === 8) {
+        var comps = /^(\d{4})(\d{2})(\d{2})$/.exec(curr.start);
+        if (comps) {
+          curr.start = new Date (comps[1], comps[2], comps[3]);
+        }
+      }
+
       rule += ';DTSTART=' + curr.start.toISOString().replace(/[-:]/g, '');
       rule = rule.replace(/\.[0-9]{3}/, '');
     }


### PR DESCRIPTION
In some cases, the curr.start is just an 8 digit string, like '20160423'. 
In that case we need to convert it to a date object. Otherwise, the
.toISOString() method will throw an exception.