### PR TITLE
Update `request` to 2.81.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "url": "git://github.com/peterbraden/ical.js.git"
   },
   "dependencies": {
-    "request": "2.75.0",
+    "request": "^2.81.0",
     "rrule": "2.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Request 2.68.0 has one high- and one medium-severity security vulnerability: https://snyk.io/test/npm/request/2.68.0