### PR TITLE
Adding license field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   ],
   "homepage": "https://github.com/peterbraden/ical.js",
   "author": "Peter Braden <peterbraden@peterbraden.co.uk> (peterbraden.co.uk)",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git://github.com/peterbraden/ical.js.git"


### PR DESCRIPTION
Hi, 
It's convenient to have the license information accessible from the package.json file.
Thanks,
Camille 