### PR TITLE
add additional validation for the curr.uid

### DIFF
--- a/ical.js
+++ b/ical.js
@@ -283,7 +283,7 @@
 
         var par = stack.pop()
 
-        if (curr.uid)
+        if (curr.uid && typeof curr.uid === 'string')
         {
         	// If this is the first time we run into this UID, just save it.
         	if (par[curr.uid] === undefined)


### PR DESCRIPTION
add additional validation for the curr.uid
if the type of "curr.uid" would be an object then the keys of resulted object after the parsing would looks like "[object Object]"
in case of "UID;VALUE=TEXT:c13f7d21-...." at the end of the parsing we would have only the last date