### PR TITLE
Make example.js functional again

### DIFF
--- a/example.js
+++ b/example.js
@@ -1,16 +1,22 @@
 'use strict';
 
+// This example uses axios for requesting the calendar
+// but is not required for use with ical.
+const axios = require('axios');
 const ical = require('ical');
 const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
 
-ical.fromURL('http://lanyrd.com/topics/nodejs/nodejs.ics', {}, function (err, data) {
-	for (let k in data) {
-		if (data.hasOwnProperty(k)) {
-			var ev = data[k];
-			if (data[k].type == 'VEVENT') {
-				console.log(`${ev.summary} is in ${ev.location} on the ${ev.start.getDate()} of ${months[ev.start.getMonth()]} at ${ev.start.toLocaleTimeString('en-GB')}`);
+axios.get('https://www.google.com/calendar/ical/en.usa%23holiday@group.v.calendar.google.com/public/basic.ics')
+    .then(function (response) {
+        var data = ical.parseICS(response.data);
+        for (let k in data) {
+            if (data.hasOwnProperty(k)) {
+                var ev = data[k];
+                if (data[k].type == 'VEVENT') {
+                    console.log(`${ev.summary} is in ${ev.location} on the ${ev.start.getDate()} of ${months[ev.start.getMonth()]} at ${ev.start.toLocaleTimeString('en-GB')}`);
 
-			}
-		}
-	}
-});
+                }
+            }
+        }
+    });
+


### PR DESCRIPTION
Change example.js to:
- Use a URL that works.
- Doesn't use deprecated fromURL function
- Uses a separate request library (axios), appropriately notes it's not required.