### PR TITLE
docs: fix typo in README installation section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@ A tolerant, minimal icalendar parser for javascript/node
 
 ## Install - Node.js ##
 
-ical.js is availble on npm:
+ical.js is available on npm:
 
     npm install ical
 


### PR DESCRIPTION
This PR fixes a simple typo in readme.md:
- `availble` → `available`

No functional changes, just documentation improvement.